### PR TITLE
v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oidc",
-  "version": "0.1.1",
+  "version": "0.1.2-0",
   "description": "Wrapper for the OIDC JavaScript client, to be used in React projects.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oidc",
-  "version": "0.1.2-0",
+  "version": "0.1.2",
   "description": "Wrapper for the OIDC JavaScript client, to be used in React projects.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/makeAuth/index.tsx
+++ b/src/makeAuth/index.tsx
@@ -33,13 +33,13 @@ function makeAuthenticator({
   userManager,
   placeholderComponent
 }: IMakeAuthenticatorParams) {
-  return (WrappedComponent: React.ReactNode) => {
+  return <Props extends {}>(WrappedComponent: React.ReactNode) => {
     return class Authenticator extends React.Component<
-      {},
+      Props,
       IAuthenticatorState
     > {
       public userManager: UserManager
-      constructor(props: {}) {
+      constructor(props: Props) {
         super(props)
         const um = userManager
         this.userManager = um

--- a/src/makeUserManager/index.ts
+++ b/src/makeUserManager/index.ts
@@ -1,7 +1,7 @@
 import { UserManager, UserManagerSettings } from 'oidc-client'
 
 function makeUserManager(
-  config: UserManagerSettings,
+  config: UserManagerSettings & { domain?: string; audience?: string },
   umClass?: any
 ): UserManager {
   const UMClass = umClass || UserManager


### PR DESCRIPTION
- Allow passing `domain` and `audience` to the UserManager (for auth0 compatibility)
- Allow specifying props on the component wrapped by `makeAuthenticator`