### PR TITLE
Implement full signOut flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oidc",
-  "version": "0.3.0",
+  "version": "0.4.0-alpha.0",
   "description": "Wrapper for the OIDC JavaScript client, to be used in React projects.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/Callback/index.tsx
+++ b/src/Callback/index.tsx
@@ -1,17 +1,25 @@
 import * as React from 'react'
-import { User, UserManager, UserManagerSettings } from 'oidc-client'
+import { User, UserManager } from 'oidc-client'
 
-export interface ICallbackProps {
+export interface ICallbackHandlers {
   onSuccess?: (user: User) => void
   onError?: (err: any) => void
+}
+export interface IRedirectCallback {
+  redirectCallback:
+    | UserManager['signinRedirectCallback']
+    | UserManager['signoutRedirectCallback']
+}
+export type ICallbackProps = ICallbackHandlers & IRedirectCallback
+export type ICallbackActionProps = ICallbackHandlers & {
   userManager: UserManager
 }
+
 class Callback extends React.Component<ICallbackProps> {
   public componentDidMount() {
-    const { onSuccess, onError, userManager } = this.props
+    const { onSuccess, onError, redirectCallback } = this.props
 
-    const um = userManager
-    um.signinRedirectCallback()
+    redirectCallback()
       .then(user => {
         if (onSuccess) {
           onSuccess(user)

--- a/src/RedirectToAuth/index.test.tsx
+++ b/src/RedirectToAuth/index.test.tsx
@@ -8,7 +8,37 @@ describe('RedirectToAuth', () => {
   it('calls signinRedirect', () => {
     const mock = jest.fn()
     const um = new MockUserManager({ signinRedirectFunction: mock })
-    render(<RedirectToAuth userManager={um} />)
+    render(<RedirectToAuth userManager={um} onSilentSuccess={jest.fn()} />)
+
+    wait(() => expect(mock).toHaveBeenCalledTimes(1))
+  })
+
+  it('calls onSilentSuccess', () => {
+    const mock = jest.fn()
+    const onSilentSuccess = jest.fn()
+    const um = new MockUserManager({
+      signinRedirectFunction: mock,
+      signinSilent: mock
+    })
+    render(
+      <RedirectToAuth userManager={um} onSilentSuccess={onSilentSuccess} />
+    )
+
+    wait(() => expect(onSilentSuccess).toHaveBeenCalledTimes(1))
+  })
+
+  it('calls signinRedirect if signinSilent fails', () => {
+    const mock = jest.fn()
+    const onSilentSuccess = jest.fn(() => {
+      throw new Error()
+    })
+    const um = new MockUserManager({
+      signinRedirectFunction: mock,
+      signinSilent: jest.fn()
+    })
+    render(
+      <RedirectToAuth userManager={um} onSilentSuccess={onSilentSuccess} />
+    )
 
     wait(() => expect(mock).toHaveBeenCalledTimes(1))
   })

--- a/src/SignInCallback/index.tsx
+++ b/src/SignInCallback/index.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+
+import Callback, { ICallbackActionProps } from '../Callback'
+
+const SignInCallback = (props: ICallbackActionProps) => {
+  return (
+    <Callback
+      onSuccess={props.onSuccess}
+      onError={props.onError}
+      redirectCallback={props.userManager.signinRedirectCallback}
+    />
+  )
+}
+
+export default SignInCallback

--- a/src/SignOutCallback/index.tsx
+++ b/src/SignOutCallback/index.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+
+import Callback, { ICallbackActionProps } from '../Callback'
+
+const SignOutCallback = (props: ICallbackActionProps) => {
+  return (
+    <Callback
+      onSuccess={props.onSuccess}
+      onError={props.onError}
+      redirectCallback={props.userManager.signoutRedirectCallback}
+    />
+  )
+}
+
+export default SignOutCallback

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,12 @@
 import { AuthenticatorContext as UserData, makeAuthenticator } from './makeAuth'
 import makeUserManager from './makeUserManager'
-import Callback from './Callback'
+import Callback from './SignInCallback'
+import SignoutCallback from './SignOutCallback'
 
-export { Callback, UserData, makeAuthenticator, makeUserManager }
+export {
+  Callback,
+  SignoutCallback,
+  UserData,
+  makeAuthenticator,
+  makeUserManager
+}

--- a/src/makeAuth/index.tsx
+++ b/src/makeAuth/index.tsx
@@ -80,7 +80,11 @@ function makeAuthenticator({
 
       public signOut = () => {
         this.userManager.removeUser()
-        this.getUser()
+        this.setState(({ context }) => ({
+          context: { ...context, user: null },
+          isFetchingUser: false
+        }))
+        this.userManager.signoutRedirect()
       }
 
       public isValid = () => {
@@ -93,7 +97,9 @@ function makeAuthenticator({
           return placeholderComponent || null
         }
         return this.isValid() ? (
-          <AuthenticatorContext.Provider value={this.state.context}>{WrappedComponent}</AuthenticatorContext.Provider>
+          <AuthenticatorContext.Provider value={this.state.context}>
+            {WrappedComponent}
+          </AuthenticatorContext.Provider>
         ) : (
           <RedirectToAuth
             userManager={this.userManager}

--- a/src/utils/userManager.ts
+++ b/src/utils/userManager.ts
@@ -1,19 +1,28 @@
 import { UserManagerSettings } from 'oidc-client'
 
-export interface IMockUserManagerOptions extends UserManagerSettings {
+export interface IOverloads {
   getUserFunction: () => Promise<any>
   signinRedirectCallback: () => Promise<any>
   signinRedirectFunction: () => void
+  signoutRedirectFunction: () => void
+  signinSilent?: () => void
 }
-class UserManager {
+export interface IMockUserManagerOptions
+  extends UserManagerSettings,
+    IOverloads {}
+class UserManager implements IOverloads {
   getUserFunction: () => Promise<any>
   signinRedirectCallbackFunction: () => Promise<any>
   signinRedirectFunction: () => void
+  signoutRedirectFunction: () => void
+  signinSilent?: () => void
 
   constructor(args: IMockUserManagerOptions) {
     this.getUserFunction = args.getUserFunction
     this.signinRedirectFunction = args.signinRedirectFunction
     this.signinRedirectCallbackFunction = args.signinRedirectCallback
+    this.signoutRedirectFunction = args.signoutRedirectFunction
+    this.signinSilent = args.signinSilent
   }
 
   getUser() {
@@ -31,6 +40,11 @@ class UserManager {
     return this.signinRedirectCallbackFunction
       ? this.signinRedirectCallbackFunction()
       : new Promise(res => res())
+  }
+  signoutRedirect(): void {
+    return this.signoutRedirectFunction
+      ? this.signoutRedirectFunction()
+      : undefined
   }
 }
 


### PR DESCRIPTION
For #7

- Refactored Callback component to be generic and call whatever redirect function it was given.
- Added a SignoutCallback component, to be rendered at the appropriate signout url.
- Call signoutRedirect in the signOut method.

This will be released in the next **0.x** release, since the implementation of `signOut` has changed.