### PR TITLE
Pass props through from HOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Example using `react-router`
 import { makeAuthenticator, makeUserManager, Callback } from 'react-oidc'
 
 // supply this yourself
+import App from '../layouts/App'
 import userManagerConfig from '../config'
 
 const userManager = makeUserManager(userManagerConfig)
@@ -30,7 +31,7 @@ const AppWithAuth = makeAuthenticator({
       foo: 15
     }
   }
-})(<App />)
+})(App)
 
 export default () => (
   <Router>

--- a/src/makeAuth/index.test.tsx
+++ b/src/makeAuth/index.test.tsx
@@ -7,6 +7,7 @@ import MockUserManager from '../utils/userManager'
 
 describe('makeAuthenticator', () => {
   const Child = () => <div>Make Auth Child</div>
+  const ChildProps = ({foo}) => <div>{foo}</div>
   const Placeholder = () => <div>Placeholder</div>
   const Logout = (props: { signOut: () => void }) => (
     <button onClick={props.signOut}>Logout</button>
@@ -22,7 +23,7 @@ describe('makeAuthenticator', () => {
 
     const WithAuth = makeAuthenticator({
       userManager: makeUserManager(userManagerConfig, MockUserManager)
-    })(<Child />)
+    })(Child)
     const { getByText } = render(<WithAuth />)
 
     await successfulGetUser
@@ -37,7 +38,7 @@ describe('makeAuthenticator', () => {
     const WithAuth = makeAuthenticator({
       userManager: makeUserManager(userManagerConfig, MockUserManager),
       placeholderComponent: <Placeholder />
-    })(<Child />)
+    })(Child)
     const { queryByText } = render(<WithAuth />)
 
     await expect(expiredGetUser()).resolves.toEqual({ expired: true })
@@ -52,7 +53,7 @@ describe('makeAuthenticator', () => {
     const WithAuth = makeAuthenticator({
       userManager: makeUserManager(userManagerConfig, MockUserManager),
       placeholderComponent: <Placeholder />
-    })(<Child />)
+    })(Child)
     const { queryByText } = render(<WithAuth />)
 
     await expect(expiredGetUser()).resolves.toEqual({ expired: true })
@@ -67,7 +68,7 @@ describe('makeAuthenticator', () => {
     const WithAuth = makeAuthenticator({
       userManager: makeUserManager(userManagerConfig, MockUserManager),
       placeholderComponent: <Placeholder />
-    })(<Child />)
+    })(Child)
     const { getByText, queryByText } = render(<WithAuth />)
 
     getByText('Placeholder')
@@ -81,9 +82,10 @@ describe('makeAuthenticator', () => {
       getUserFunction: successfulGetUser
     } as any
 
+    const SignOut = () => (<AuthenticatorContext.Consumer>{({ signOut }) => <Logout signOut={signOut} />}</AuthenticatorContext.Consumer>);
     const WithAuth = makeAuthenticator({
       userManager: makeUserManager(userManagerConfig, MockUserManager)
-    })(<AuthenticatorContext.Consumer>{({ signOut }) => <Logout signOut={signOut} />}</AuthenticatorContext.Consumer>)
+    })(SignOut)
     const { getByText, queryByText } = render(<WithAuth />)
 
     await successfulGetUser
@@ -91,5 +93,20 @@ describe('makeAuthenticator', () => {
 
     fireEvent.click(button)
     waitForElement(() => expect(queryByText('Logout')).toBeNull())
+  })
+  
+  it('has props passed through', async () => {
+    const userManagerConfig = {
+      getUserFunction: successfulGetUser
+    } as any
+
+    const WithAuth = makeAuthenticator({
+      userManager: makeUserManager(userManagerConfig, MockUserManager),
+      placeholderComponent: <Placeholder />
+    })(ChildProps)
+    const { getByText } = render(<WithAuth foo="bar" />)
+
+    await successfulGetUser
+    getByText('bar')
   })
 })

--- a/src/makeAuth/index.tsx
+++ b/src/makeAuth/index.tsx
@@ -35,7 +35,7 @@ function makeAuthenticator({
   placeholderComponent,
   signinArgs
 }: IMakeAuthenticatorParams) {
-  return <Props extends {}>(WrappedComponent: React.ReactNode) => {
+  return <Props extends {}>(WrappedComponent: React.ComponentType<Props>) => {
     return class Authenticator extends React.Component<
       Props,
       IAuthenticatorState
@@ -97,7 +97,9 @@ function makeAuthenticator({
           return placeholderComponent || null
         }
         return this.isValid() ? (
-          <AuthenticatorContext.Provider value={this.state.context}>{WrappedComponent}</AuthenticatorContext.Provider>
+          <AuthenticatorContext.Provider value={this.state.context}>
+            <WrappedComponent {...this.props} />
+          </AuthenticatorContext.Provider>
         ) : (
           <RedirectToAuth
             userManager={this.userManager}


### PR DESCRIPTION
WrappedComponent has changed to a React.ComponentType

Fixes #14 

I haven't done much Typescript. Hoping React.ComponentType is correct. 

Output of `yarn build`
```
yarn run v1.17.3
$ rm -rf ./lib && tsc
Done in 2.24s.
```