### PR TITLE
Add `signinRedirect` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,11 @@ Helper utility to create a `UserManager` instance.
 
 ### `makeAuthenticator(params)(<ProtectedApp />)`
 
-| Param                  | Type          | Required | Default Value | Description                                                      |
-| ---------------------- | ------------- | -------- | ------------- | ---------------------------------------------------------------- |
-| `userManager`          | `UserManager` | Yes      | `undefined`   | `UserManager` instance (the result of `makeUserManager()`)       |
-| `placeholderComponent` | Component     | No       | `null`        | Optional component to render while auth state is being retrieved |
+| Param                  | Type          | Required | Default Value | Description                                                                                           |
+| ---------------------- | ------------- | -------- | ------------- | ----------------------------------------------------------------------------------------------------- |
+| `userManager`          | `UserManager` | Yes      | `undefined`   | `UserManager` instance (the result of `makeUserManager()`)                                            |
+| `placeholderComponent` | Component     | No       | `null`        | Optional component to render while auth state is being retrieved                                      |
+| `signinRedirect`       | boolean       | No       | `false`       | Determines if oidc should use `signinRedirect`/`signoutRedirect` by default instead of `signinSilent` |
 
 This is a higher-order function that accepts a `UserManager` instance, and optionally a placeholder component to render when user auth state is being retrieved. It returns a function that accepts a React component. This component should contain all components that you want to be protected by your authentication. Ultimately you will get back a component that either renders the component you passed it (if the user is authenticated), or redirects to the OIDC login screen as defined by the Identity Provider.
 

--- a/src/RedirectToAuth/index.tsx
+++ b/src/RedirectToAuth/index.tsx
@@ -4,11 +4,12 @@ import { UserManager, User } from 'oidc-client'
 export interface IRedirectToAuthProps {
   userManager: UserManager
   onSilentSuccess: (user: User) => void
-  signinArgs?: any
+  signinArgs?: any,
+  signinRedirect?: boolean,
 }
 class RedirectToAuth extends React.Component<IRedirectToAuthProps> {
   public async componentDidMount() {
-    if (this.props.userManager.signinSilent) {
+    if (!this.props.signinRedirect && this.props.userManager.signinSilent) {
       try {
         const user = await this.props.userManager.signinSilent(this.props.signinArgs)
         this.props.onSilentSuccess(user)

--- a/src/makeAuth/index.tsx
+++ b/src/makeAuth/index.tsx
@@ -29,11 +29,13 @@ export interface IMakeAuthenticatorParams {
   placeholderComponent?: React.ReactNode
   userManager?: UserManager
   signinArgs?: any
+  signinRedirect?: boolean
 }
 function makeAuthenticator({
   userManager,
   placeholderComponent,
-  signinArgs
+  signinArgs,
+  signinRedirect,
 }: IMakeAuthenticatorParams) {
   return <Props extends {}>(WrappedComponent: React.ComponentType<Props>) => {
     return class Authenticator extends React.Component<
@@ -42,11 +44,13 @@ function makeAuthenticator({
     > {
       public userManager: UserManager
       public signinArgs: any
+      public signinRedirect: boolean
       constructor(props: Props) {
         super(props)
         const um = userManager
         this.userManager = um
         this.signinArgs = signinArgs
+        this.signinRedirect = signinRedirect
         this.state = {
           context: {
             signOut: this.signOut,
@@ -83,6 +87,10 @@ function makeAuthenticator({
       }
 
       public signOut = () => {
+        if (this.signinRedirect) {
+          this.userManager.signoutRedirect()
+          this.storeUser(null)
+        }
         this.userManager.removeUser()
         this.getUser()
       }
@@ -105,6 +113,7 @@ function makeAuthenticator({
             userManager={this.userManager}
             onSilentSuccess={this.storeUser}
             signinArgs={this.signinArgs}
+            signinRedirect={this.signinRedirect}
           >
             {placeholderComponent}
           </RedirectToAuth>


### PR DESCRIPTION
I was having issues with `signinSilent` being the default behavior at login, so I created a new parameter for `makeAuthenticator` to directly use `signinRedirect` instead. This did run into some concurrency issues at sign-out (i.e. calling `signOut` but not ending with an empty user when immediately trying to re-authenticate), so I also modified `signOut` to use `signoutRedirect` and force-clean its user when this parameter is passed.