### PR TITLE
Fix signout

### DIFF
--- a/src/makeAuth/index.tsx
+++ b/src/makeAuth/index.tsx
@@ -83,9 +83,10 @@ function makeAuthenticator({
       }
 
       public signOut = () => {
-        this.userManager.removeUser()
-        this.getUser()
-      }
+        this.userManager.removeUser();
+        this.userManager.signoutRedirect();
+        this.getUser();
+      };
 
       public isValid = () => {
         const { user } = this.state.context

--- a/src/utils/userManager.ts
+++ b/src/utils/userManager.ts
@@ -4,16 +4,22 @@ export interface IMockUserManagerOptions extends UserManagerSettings {
   getUserFunction: () => Promise<any>
   signinRedirectCallback: () => Promise<any>
   signinRedirectFunction: () => void
+  signoutRedirectFunction: () => void
+  signoutRedirectCallback: () => Promise<any>
 }
 class UserManager {
   getUserFunction: () => Promise<any>
   signinRedirectCallbackFunction: () => Promise<any>
   signinRedirectFunction: () => void
+  signoutRedirectFunction: () => void
+  signoutRedirectCallbackFunction: () => Promise<any>
 
   constructor(args: IMockUserManagerOptions) {
     this.getUserFunction = args.getUserFunction
     this.signinRedirectFunction = args.signinRedirectFunction
     this.signinRedirectCallbackFunction = args.signinRedirectCallback
+    this.signoutRedirectFunction = args.signoutRedirectFunction
+    this.signoutRedirectCallbackFunction = args.signoutRedirectCallback
   }
 
   getUser() {
@@ -31,6 +37,17 @@ class UserManager {
     return this.signinRedirectCallbackFunction
       ? this.signinRedirectCallbackFunction()
       : new Promise(res => res())
+  }
+
+  signoutRedirect(): void {
+    return this.signoutRedirectFunction
+      ? this.signoutRedirectFunction()
+      : undefined;
+  }
+  signoutRedirectCallback() {
+    return this.signoutRedirectCallbackFunction
+      ? this.signoutRedirectCallbackFunction()
+      : undefined;
   }
 }
 


### PR DESCRIPTION
Issue
------------
Fixes #29 

Description
------------
adds the call to signoutredirect() before getUser() in signout method.

[X] Tests Pass
[X] npm version patch ran
[X] signout ends session in ADFS